### PR TITLE
handle nil object in case of dumponly-mode

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -97,7 +97,9 @@ func processData(storageConnector *connector.StorageConnector, data map[string]i
 		logger.Error("processData: error marshalling output", "err", err)
 	}
 
-	storageConnector.ImportResults(mapKey, obj)
+	if storageConnector != nil {
+		storageConnector.ImportResults(mapKey, obj)
+	}
 	AWSResults[mapKey] = data[mapKey]
 }
 


### PR DESCRIPTION
## Summary

When `--dump-only` is set to true, import operations to neo4j should be skipped. However, currently a `runtime error: invalid memory address or nil pointer dereference` error is returned.

This happens because a `nil` storage connector [is passed in dumpOnly mode](https://github.com/primait/nuvola/blob/8d80327ca3acb5fa07ccc324b56d9c90c2c81e6b/cmd/dump.go#L55), which is then used to try to import results in neo4j.

## Checks

- [x] I have addressed any CI failures that surfaced when I created my pull request
